### PR TITLE
Update css minification

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "Apps For X Light",
+  "name": "AppsForXLight",
   "version": "0.0.1",
   "authors": [
     "Wesley Vanbrabnt"

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,9 +1,8 @@
 var gulp = require('gulp');
 var gutil = require('gulp-util');
-var bower = require('bower');
 var concat = require('gulp-concat');
 var sass = require('gulp-sass');
-var minifyCss = require('gulp-minify-css');
+var cleanCSS = require('gulp-clean-css');
 var rename = require('gulp-rename');
 
 var paths = {
@@ -18,7 +17,7 @@ gulp.task('sass', function(done) {
       errLogToConsole: true
     }))
     .pipe(gulp.dest('./css/'))
-    .pipe(minifyCss({
+    .pipe(cleanCSS({
       keepSpecialComments: 0
     }))
     .pipe(rename({ extname: '.min.css' }))

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "bower": "*",
     "gulp": "*",
     "gulp-concat": "*",
-    "gulp-minify-css": "*",
+    "gulp-clean-css": "^2.0.12",
     "gulp-rename": "*",
     "gulp-sass": "*",
     "gulp-util": "*"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Apps For X Light",
+  "name": "AppsForXLight",
   "version": "0.0.1",
   "description": "Onepage template for small hackathons that is very lightweight. Only the essentials.",
   "license": "MIT",
@@ -19,7 +19,11 @@
     "gulp-util": "*"
   },
   "bugs": {
-    "url": ""
+    "url": "https://github.com/openknowledgebe/AppsForXLight/issues"
   },
-  "homepage": ""
+  "homepage": "https://github.com/openknowledgebe/AppsForXLight",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/openknowledgebe/AppsForXLight.git"
+  }
 }


### PR DESCRIPTION
depends on #5 to be merged.

`gulp-minify-css` is deprecated and replaced by `gulp-clean-css`
